### PR TITLE
Updates to support different integration time modes for AV3

### DIFF
--- a/av3rdn.py
+++ b/av3rdn.py
@@ -143,10 +143,14 @@ class Config:
             self.wl_full, self.fwhm_full = None, None
 
         if hasattr(fpa,'srf_correction_file'):
-            self.srf_correction = np.fromfile(fpa.srf_correction_file,
-                 dtype = np.float32).reshape((fpa.native_rows, fpa.native_rows))
-            self.crf_correction = np.fromfile(fpa.crf_correction_file,
-                 dtype = np.float32).reshape((fpa.native_columns, fpa.native_columns))
+            try:
+                self.srf_correction = np.fromfile(fpa.srf_correction_file,
+                     dtype = np.float32).reshape((fpa.native_rows, fpa.native_rows))
+                self.crf_correction = np.fromfile(fpa.crf_correction_file,
+                     dtype = np.float32).reshape((fpa.native_columns, fpa.native_columns))
+            except ValueError:
+                self.srf_correction = np.loadtxt(fpa.srf_correction_file) #New version of correction
+                self.crf_correction = np.loadtxt(fpa.crf_correction_file)
         else:
             self.srf_correction = None
             self.crf_correction = None
@@ -172,7 +176,7 @@ class Config:
             _, self.radiometric_calibration, self.radiometric_uncert = \
                  np.loadtxt(self.radiometric_coefficient_file).T
 
-            self.radiometric_calibration /= integration_time
+            #self.radiometric_calibration /= integration_time
         else:
             self.radiometric_calibration, self.radiometric_uncert = None, None
 
@@ -399,7 +403,14 @@ def main():
     else:
         integration_time = args.integration_time
 
-    config = Config(fpa, args.mode, integration_time)
+    if integration_time < 1:
+        mode = f'int{integration_time*100:.0f}pct'
+    else:
+        mode = args.mode
+    logging.info(f'Using mode {mode} for integration time {integration_time}')
+    # Likely need to add a try/except in Config to catch the case where mode doesn't exist and revert to default
+
+    config = Config(fpa, mode, integration_time)
 
     logging.info('Initializing ray')
     ray.init(num_cpus=args.max_jobs,ignore_reinit_error=True)

--- a/utils/av3_shutter_position.py
+++ b/utils/av3_shutter_position.py
@@ -125,13 +125,18 @@ def get_shutter_states(input_file, rows = 328, dark_sec=10, transition_sec=3.5, 
             obc[leading_science_frames] = 2
 
         transitions = obc[1:]-obc[:-1]
-        science_to_dark = np.argwhere(transitions  == -1)[0][0]
+        try:
+            science_to_dark = np.argwhere(transitions  == -1)[0][0]
+        except IndexError:
+            science_to_dark = -1
+            print('No 2nd shutter state detected, using all end frames')
 
         shutter_state = np.zeros(len(obc))
         shutter_state[dark_to_science:dark_to_science+int(transition_sec*fps)] = 1
         shutter_state[dark_to_science+int(transition_sec*fps):science_to_dark-int(transition_sec*fps)] = 2
-        shutter_state[science_to_dark-int(transition_sec*fps):science_to_dark] = 3
-        shutter_state[science_to_dark:] = 4
+        if science_to_dark > 0:
+            shutter_state[science_to_dark-int(transition_sec*fps):science_to_dark] = 3
+            shutter_state[science_to_dark:] = 4
 
 
     return shutter_state

--- a/utils/fixscatter.py
+++ b/utils/fixscatter.py
@@ -26,13 +26,41 @@ def find_header(infile):
   else:
     raise FileNotFoundError('Did not find header file')
 
+def psf(x, mean=0, sigma=1.):
+    q = np.exp(-0.5 * ((x - mean) / sigma)**2)
+    q = q/sum(q)
+    return q
+    
+def blur_matrix(x, sigma):
+    psfs = []
+    for i in range(len(x)):
+        q = psf(x, x[i], sigma)
+        psfs.append(q)
+    return np.array(psfs)
+    
+def deconvolve(frame, sigma_spectral=20, sigma_spatial=20, amplitude=0.0115):
+    xa = np.arange(frame.shape[0])
+    xb = np.arange(frame.shape[1])
+    spectral_blur = blur_matrix(xa, sigma_spectral)
+    spatial_blur = blur_matrix(xb, sigma_spatial)
+    Q = (spatial_blur @ (spectral_blur @ frame).T).T
+    fixed = (frame - amplitude * Q)
+    fixed = fixed/sum(fixed)*sum(frame)
+    return fixed
+
 
 def fix_scatter(frame, spectral_correction, spatial_correction):
-   if frame.shape[0] != spectral_correction.shape[0] or \
-       frame.shape[1] != spatial_correction.shape[1]:
-       logging.error('Mismatched frame size')
-   fixed = spectral_correction @ (spatial_correction @ frame.T).T
-   return fixed
+    if frame.shape[0] != spectral_correction.shape[0] or \
+        frame.shape[1] != spatial_correction.shape[1]:
+        if spectral_correction.shape[0] == 2:
+            fixed = deconvolve(frame,sigma_spectral = spectral_correction[0],\
+                              sigma_spatial = spatial_correction[0],\
+                              amplitude = spectral_correction[1])
+        else:
+            logging.error('Mismatched frame size')
+    else:
+        fixed = spectral_correction @ (spatial_correction @ frame.T).T
+    return fixed
 
 
 def main():

--- a/utils/pedestal.py
+++ b/utils/pedestal.py
@@ -34,8 +34,9 @@ def fix_pedestal(frame, fpa):
        avg = frame[mask].mean() * fpa.pedestal_multiplier 
        frame = frame - avg
        return frame
-    if fpa.pedestal_strategy == 'row-average': 
-        pedestal = np.mean(frame[fpa.masked_rows,:]) #Testing only
+    if (fpa.pedestal_strategy == 'row-average' or \
+           fpa.pedestal_strategy == 'row-average-columns'): 
+        pedestal = np.median(frame[fpa.masked_rows,:]) 
         pedestal = pedestal * fpa.pedestal_multiplier
         frame = frame - pedestal
     if fpa.pedestal_strategy == 'column-average': 
@@ -43,7 +44,8 @@ def fix_pedestal(frame, fpa):
         pedestal = pedestal * fpa.pedestal_multiplier
         frame = frame - pedestal
     if (fpa.pedestal_strategy == 'columns' or \
-          fpa.pedestal_strategy == 'both') and \
+          fpa.pedestal_strategy == 'both' or \
+          fpa.pedestal_strategy == 'row-average-columns') and \
           len(fpa.masked_cols)>0:
         pedestal = np.median(frame[:,fpa.masked_cols], axis=1)
         pedestal = pedestal * fpa.pedestal_multiplier


### PR DESCRIPTION
Some random updates:
1. Including different integration time modes for AV3
2. Adding a pedestal shift option ("row-average-column") - just for testing, but it ended up as part of a different commit, my bad
3. Adding error handling for when there is no second shutter captured by accident
4. Adding support for new scatter parameterization for AV3